### PR TITLE
Add amd64 build support (0.15.1)

### DIFF
--- a/calendar2image/CHANGELOG.md
+++ b/calendar2image/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.15.1] - 2026-02-09
+
+### Fixed
+- Add amd64 build support so the add-on can install on x86_64/Proxmox hosts
+
 ## [0.15.0] - 2026-01-18
 
 ### Added
@@ -235,9 +240,9 @@ Sharp's built-in `gamma()` function is optimized for image resize operations and
 
 ### Changed
 - **Timezone Configuration - Breaking Change for Deprecated Abbreviations**
-  - ⚠️ **Action Required**: If you use timezone abbreviations like `"CET"`, `"EST"`, `"PST"`, etc., update your configuration to use proper IANA timezone names
-  - Replace `"CET"` with region-based names like `"Europe/Brussels"`, `"Europe/Berlin"`, etc.
-  - Replace `"EST"` with `"America/New_York"`, `"PST"` with `"America/Los_Angeles"`, etc.
+  - ⚠️ **Action Required**: If you use timezone abbreviations like "CET", "EST", "PST", etc., update your configuration to use proper IANA timezone names
+  - Replace "CET" with region-based names like "Europe/Brussels", "Europe/Berlin", etc.
+  - Replace "EST" with "America/New_York", "PST" with "America/Los_Angeles", etc.
   - See [IANA Timezone Database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for valid timezone names
 
 ### Fixed
@@ -288,11 +293,6 @@ Sharp's built-in `gamma()` function is optimized for image resize operations and
   - CRC32 blocks now properly group consecutive events with the same image version
   - Non-CRC32 events (ICS, config, system, errors) continue to display in chronological order
 
-### Technical Details
-- ExtraData cache hits and stale serves no longer create timeline events
-- Timeline page CRC32 grouping now works correctly without interruptions from cache events
-- Console logging still provides full visibility into cache behavior for debugging
-
 ## [0.8.6] - 2025-11-08
 
 ### Added
@@ -310,7 +310,7 @@ Sharp's built-in `gamma()` function is optimized for image resize operations and
 ### Technical Details
 - ExtraData cache files stored in cache directory with MD5-hashed filenames
 - Background refresh prevents duplicate fetches with tracking
-- Comprehensive logging: cache hits, stale serves, refreshes, and errors
+- Comprehensive logging: cache hits, misses, stale serves, refreshes, and errors
 - Timeline events: `EXTRA_DATA_FETCH`, `EXTRA_DATA_CACHE_HIT`, `EXTRA_DATA_STALE_SERVE`, `EXTRA_DATA_REFRESH`, `EXTRA_DATA_ERROR`
 
 ## [0.8.5] - 2025-11-08

--- a/calendar2image/build.yaml
+++ b/calendar2image/build.yaml
@@ -1,3 +1,4 @@
 build_from:
+  amd64: ghcr.io/home-assistant/amd64-base:3.20
   aarch64: ghcr.io/home-assistant/aarch64-base:3.20
   armv7: ghcr.io/home-assistant/armv7-base:3.20

--- a/calendar2image/config.yaml
+++ b/calendar2image/config.yaml
@@ -1,9 +1,10 @@
 name: HA Calendar2Image
-version: "0.15.0"
+version: "0.15.1"
 slug: calendar2image
 description: Transform calendars, other data, or both into customizable images - supports ICS feeds, external data sources, custom templates, intelligent caching, and e-ink optimization for ultra-low-power displays.
 url: https://github.com/jantielens/ha-calendar2image
 arch:
+  - amd64
   - aarch64
   - armv7
 init: false

--- a/calendar2image/package.json
+++ b/calendar2image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-calendar2image",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Transform calendars, other data, or both into customizable images - supports ICS feeds, external data sources, custom templates, intelligent caching, and e-ink optimization for ultra-low-power displays.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Description
Add amd64 build support so the add-on can be installed on x86_64/Proxmox hosts, and bump patch version to 0.15.1.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update

## Checklist

### Version and Documentation
- [x] Updated version in `package.json`
- [x] Updated version in `config.yaml`
- [x] Updated `CHANGELOG` with changes
- [ ] Reviewed and updated all `.md` files if needed

### Code Quality
- [x] Code follows ES6+ JavaScript syntax
- [x] Code follows Home Assistant add-on best practices
- [x] Code is compatible with Home Assistant's Docker environment
- [x] Code follows the KISS principle (Keep It Simple, Stupid)

### Performance
- [x] Changes are optimized for fast CRC32 & image downloads (critical for ESP32 battery consumption)
- [x] No unnecessary performance bottlenecks introduced

### Testing
- [ ] All automated tests pass
- [ ] Tested in a Home Assistant environment (if applicable)
- [ ] Tested with ICS calendar data (if applicable)

## Related Issues
Fixes #

## Additional Notes
Tests not run (not requested).