### PR TITLE
fix: prevent leaked Puppeteer Chrome profile dirs filling /tmp

### DIFF
--- a/calendar2image/CHANGELOG.md
+++ b/calendar2image/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.15.2] - 2026-06-10
+
+### Fixed
+- Prevent unbounded disk growth from leaked Puppeteer Chrome profile directories in `/tmp`
+  - Image generation now uses a controlled, uniquely named `userDataDir` and removes it after each render
+  - Browser is closed before the image worker process exits, and a process `exit` safety net synchronously removes the profile directory even if the browser does not close cleanly
+  - Stale `puppeteer_dev_chrome_profile-*` and `c2i-chrome-profile-*` directories are reaped on startup and on container (re)start to reclaim space from previous versions
+
 ## [0.15.1] - 2026-02-09
 
 ### Fixed

--- a/calendar2image/config.yaml
+++ b/calendar2image/config.yaml
@@ -1,5 +1,5 @@
 name: HA Calendar2Image
-version: "0.15.1"
+version: "0.15.2"
 slug: calendar2image
 description: Transform calendars, other data, or both into customizable images - supports ICS feeds, external data sources, custom templates, intelligent caching, and e-ink optimization for ultra-low-power displays.
 url: https://github.com/jantielens/ha-calendar2image

--- a/calendar2image/package.json
+++ b/calendar2image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-calendar2image",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Transform calendars, other data, or both into customizable images - supports ICS feeds, external data sources, custom templates, intelligent caching, and e-ink optimization for ultra-low-power displays.",
   "main": "src/index.js",
   "scripts": {

--- a/calendar2image/rootfs/etc/services.d/calendar2image/run
+++ b/calendar2image/rootfs/etc/services.d/calendar2image/run
@@ -19,5 +19,11 @@ export TEMPLATES_DIR=/config/templates
 export ADDON_SLUG=${ADDON_SLUG:-calendar2image}
 export HOST_CONFIG_PATH=${HOST_CONFIG_PATH:-/addon_configs/${ADDON_SLUG}}
 
+# Reclaim disk space from leftover Chrome profile directories before starting.
+# Older versions could leak `puppeteer_dev_chrome_profile-*` dirs into /tmp,
+# accumulating to many GB. This clears them on every (re)start as a safety net.
+echo "[INFO] Cleaning up stale Chrome profile directories in /tmp..."
+rm -rf /tmp/puppeteer_dev_chrome_profile-* /tmp/c2i-chrome-profile-* 2>/dev/null || true
+
 cd /app
 exec node src/index.js

--- a/calendar2image/src/image/browser.js
+++ b/calendar2image/src/image/browser.js
@@ -1,4 +1,7 @@
 const puppeteer = require('puppeteer');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
 
 /**
  * Singleton browser instance manager
@@ -10,9 +13,82 @@ const puppeteer = require('puppeteer');
  * - Testing: Monitor in production, may need to switch to per-request launch if unstable
  */
 
+// Prefix used for the Chrome user-data (profile) directories we create.
+// By specifying our own userDataDir we avoid Puppeteer's auto-generated
+// `puppeteer_dev_chrome_profile-*` dirs, and we can reliably clean them up
+// ourselves even if the browser does not close gracefully.
+const PROFILE_PREFIX = 'c2i-chrome-profile-';
+// Puppeteer's default auto-generated prefix, reaped on startup to clean up
+// leftovers from older add-on versions or crashed worker processes.
+const PUPPETEER_DEFAULT_PREFIX = 'puppeteer_dev_chrome_profile-';
+
 let browserInstance = null;
 let isLaunching = false;
 let launchPromise = null;
+let currentUserDataDir = null;
+
+/**
+ * Synchronously remove the current Chrome user-data directory, if any.
+ *
+ * Uses synchronous fs so it can run safely from a `process.on('exit')`
+ * handler. Best-effort: never throws.
+ */
+function cleanupUserDataDirSync() {
+  if (!currentUserDataDir) {
+    return;
+  }
+  const dir = currentUserDataDir;
+  currentUserDataDir = null;
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (error) {
+    // Best-effort cleanup; never throw from here.
+    console.error(`Error removing Chrome user-data dir ${dir}:`, error.message);
+  }
+}
+
+/**
+ * Remove stale Chrome profile directories left behind by previous runs.
+ *
+ * This reaps both our own `c2i-chrome-profile-*` directories and Puppeteer's
+ * default `puppeteer_dev_chrome_profile-*` directories from the temp dir,
+ * cleaning up leaks from older add-on versions or processes killed before
+ * they could clean up after themselves. Best-effort: never throws.
+ *
+ * @returns {number} Number of directories removed
+ */
+function reapStaleProfiles() {
+  const tmp = os.tmpdir();
+  let removed = 0;
+  let entries = [];
+  try {
+    entries = fs.readdirSync(tmp);
+  } catch (error) {
+    console.error(`Error reading temp dir ${tmp} for stale profiles:`, error.message);
+    return removed;
+  }
+
+  for (const entry of entries) {
+    if (entry.startsWith(PROFILE_PREFIX) || entry.startsWith(PUPPETEER_DEFAULT_PREFIX)) {
+      // Don't remove the profile the current process is actively using.
+      const fullPath = path.join(tmp, entry);
+      if (fullPath === currentUserDataDir) {
+        continue;
+      }
+      try {
+        fs.rmSync(fullPath, { recursive: true, force: true });
+        removed++;
+      } catch (error) {
+        console.error(`Error removing stale profile ${fullPath}:`, error.message);
+      }
+    }
+  }
+
+  if (removed > 0) {
+    console.log(`Reaped ${removed} stale Chrome profile director${removed === 1 ? 'y' : 'ies'} from ${tmp}`);
+  }
+  return removed;
+}
 
 /**
  * Get or create the browser instance
@@ -55,8 +131,20 @@ async function launchBrowser() {
   console.log(`PUPPETEER_EXECUTABLE_PATH env: ${process.env.PUPPETEER_EXECUTABLE_PATH}`);
   console.log(`Using executable path: ${chromiumPath}`);
 
+  // Clean up any directory left over from a previous launch in this same
+  // process (e.g. after an unexpected browser disconnect/crash) before we
+  // create a new one, so references are never lost.
+  cleanupUserDataDirSync();
+
+  // Use our own controlled, unique user-data directory instead of letting
+  // Puppeteer auto-create one. This lets us reliably remove it on shutdown
+  // (or via the process 'exit' handler) even if browser.close() never runs
+  // or fails, preventing unbounded /tmp growth.
+  currentUserDataDir = path.join(os.tmpdir(), `${PROFILE_PREFIX}${process.pid}-${Date.now()}`);
+
   const launchOptions = {
     headless: true,
+    userDataDir: currentUserDataDir,
     args: [
       '--no-sandbox',
       '--disable-setuid-sandbox',
@@ -97,7 +185,12 @@ async function closeBrowser() {
       console.error('Error closing browser:', error);
     } finally {
       browserInstance = null;
+      // Remove the profile directory regardless of whether close() succeeded.
+      cleanupUserDataDirSync();
     }
+  } else {
+    // No live browser, but a directory may still linger (e.g. after a crash).
+    cleanupUserDataDirSync();
   }
 }
 
@@ -122,8 +215,17 @@ process.on('SIGINT', async () => {
   await closeBrowser();
 });
 
+// Last-resort safety net: synchronously remove the profile directory on any
+// process exit. This runs even when the process exits via process.exit()
+// without browser.close() being awaited (e.g. the image worker), guaranteeing
+// the Chrome user-data dir is never leaked into /tmp.
+process.on('exit', () => {
+  cleanupUserDataDirSync();
+});
+
 module.exports = {
   getBrowser,
   closeBrowser,
-  createPage
+  createPage,
+  reapStaleProfiles
 };

--- a/calendar2image/src/image/browser.js
+++ b/calendar2image/src/image/browser.js
@@ -159,7 +159,16 @@ async function launchBrowser() {
 
   console.log('Launch options:', JSON.stringify(launchOptions, null, 2));
 
-  const browser = await puppeteer.launch(launchOptions);
+  let browser;
+  try {
+    browser = await puppeteer.launch(launchOptions);
+  } catch (error) {
+    // If launch fails (bad Chromium path, sandbox error, etc.), Chromium may
+    // have already created the profile dir. Remove it before rethrowing so
+    // repeated launch failures don't leak directories into /tmp.
+    cleanupUserDataDirSync();
+    throw error;
+  }
 
   console.log('Puppeteer browser launched successfully');
 

--- a/calendar2image/src/image/worker.js
+++ b/calendar2image/src/image/worker.js
@@ -8,6 +8,7 @@
  */
 
 const { generateImage } = require('./index');
+const { closeBrowser } = require('./browser');
 const { renderTemplate } = require('../templates');
 const { getCalendarEvents } = require('../calendar');
 const { loadConfig } = require('../config');
@@ -164,6 +165,10 @@ async function generateCalendarImageInWorker(name, trigger = 'unknown') {
       eventCount: events.length
     });
     
+    // Close the browser to release Chrome and remove its temporary profile
+    // directory before exiting (the process 'exit' handler is a backstop).
+    await closeBrowser();
+
     // Exit cleanly
     process.exit(0);
     
@@ -191,6 +196,10 @@ async function generateCalendarImageInWorker(name, trigger = 'unknown') {
       duration: duration
     });
     
+    // Close the browser to release Chrome and remove its temporary profile
+    // directory before exiting (the process 'exit' handler is a backstop).
+    await closeBrowser();
+
     // Exit with error
     process.exit(1);
   }

--- a/calendar2image/src/index.js
+++ b/calendar2image/src/index.js
@@ -6,6 +6,7 @@ const { handleConfigPage } = require('./api/configHandler');
 const { handleTimelinePage } = require('./api/timelineHandler');
 const { ensureCacheDir } = require('./cache');
 const { initializeScheduler, generateAllImagesNow, stopAllSchedules } = require('./scheduler');
+const { reapStaleProfiles } = require('./image/browser');
 const { getVersion } = require('./utils/version');
 
 const app = express();
@@ -148,6 +149,11 @@ const server = app.listen(PORT, '0.0.0.0', async () => {
     console.log('='.repeat(50));
     
     try {
+        // Reap stale Chrome profile directories left behind by previous runs
+        // or older add-on versions (prevents unbounded /tmp growth).
+        console.log('Reaping stale Chrome profile directories...');
+        reapStaleProfiles();
+
         // Initialize cache directory
         console.log('Initializing cache system...');
         await ensureCacheDir();


### PR DESCRIPTION
## Summary

Fixes a disk-space leak where the add-on accumulated `/tmp/puppeteer_dev_chrome_profile-*` directories without bound. A reporter observed **4,048 leftover dirs totaling 11.3 GB** in the container's writable layer (v0.15.1).

## Root cause

Each image render runs in a forked worker process (`src/image/worker.js`). The worker launches a fresh Puppeteer browser, and with no `userDataDir` specified Puppeteer auto-creates `/tmp/puppeteer_dev_chrome_profile-XXXXXX`. The worker then calls `process.exit(0)` directly, which **does not trigger** the `SIGTERM`/`SIGINT` handlers that called `browser.close()`. As a result the browser was never closed and its temp profile dir was orphaned on every single generation.

## Fix (defense-in-depth)

The fix is layered so it holds even if the browser does not shut down cleanly:

- **Controlled profile dir** — Chrome now launches with our own unique `userDataDir` (`/tmp/c2i-chrome-profile-<pid>-<timestamp>`) and `closeBrowser()` removes it regardless of whether `browser.close()` succeeded.
- **Process `exit` safety net** — a `process.on('exit')` handler synchronously removes the profile dir, so it is reclaimed even when the worker exits via `process.exit()` without awaiting `browser.close()`.
- **Worker cleanup** — `await closeBrowser()` before `process.exit()` in both success and error paths.
- **Stale-profile reaper** — sweeps both `puppeteer_dev_chrome_profile-*` and `c2i-chrome-profile-*` on startup (`src/index.js`) and in the service `run` script before Node starts, reclaiming leftovers from older versions / killed workers on the next restart.

## Removal of existing leftovers

- **On add-on update**: the old container's writable layer (where `/tmp` lives) is discarded by Docker, reclaiming the space automatically.
- **On plain restart**: the run-script `rm -rf` and startup reaper clear the leftovers.

## Testing

- All 283 unit tests pass (`npx jest`).
- Real-Chrome `browser.test.js` runs under the container config (`npm run test:ci`).

## Checklist

- [x] Version bumped in `package.json` and `config.yaml` (0.15.1 → 0.15.2)
- [x] CHANGELOG.md updated
- [x] All unit tests pass
